### PR TITLE
Fix condition in `allDayEvents`

### DIFF
--- a/Clendar/Helper/Extensions/ClendarEvent+Extensions.swift
+++ b/Clendar/Helper/Extensions/ClendarEvent+Extensions.swift
@@ -14,6 +14,6 @@ extension Array where Element == ClendarEvent {
     }
 
     var allDayEvents: [ClendarEvent] {
-        filter { $0.event?.isAllDay == false }
+        filter { $0.event?.isAllDay == true }
     }
 }


### PR DESCRIPTION
The getter for `allDayEvents` (currently unused) is identical to `nonAllDayEvents`, which doesn't seem right.